### PR TITLE
fix(webhook): retry the WhatsApp status update through transient 1020…

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
@@ -46,7 +46,7 @@ class TestApplyWhatsappMessageStatus(FrappeTestCase):
         _m_get, m_set, m_commit, m_rb, m_log = self._run(set_value_side_effect=se)
         self.assertEqual(m_set.call_count, 3, "set_value retried until it succeeds")
         self.assertEqual(m_commit.call_count, 1, "commit once, after the successful UPDATE")
-        self.assertEqual(m_rb.call_count, 2, "rollback before each of the 2 retries (fresh snapshot)")
+        self.assertEqual(m_rb.call_count, 3, "one up-front rollback + before each of the 2 retries (fresh snapshot)")
         m_log.assert_not_called()
 
     def test_exhaustion_logs_once_and_does_not_raise(self):
@@ -56,8 +56,12 @@ class TestApplyWhatsappMessageStatus(FrappeTestCase):
             raise frappe.QueryTimeoutError("1205 lock wait timeout")
 
         _m_get, m_set, m_commit, m_rb, m_log = self._run(set_value_side_effect=se)  # must not raise
-        self.assertEqual(m_set.call_count, 5, "exactly _STATUS_RETRY_ATTEMPTS attempts")
-        self.assertEqual(m_rb.call_count, 5)
+        self.assertEqual(m_set.call_count, webhook._STATUS_RETRY_ATTEMPTS, "one set_value per attempt")
+        self.assertEqual(
+            m_rb.call_count,
+            webhook._STATUS_RETRY_ATTEMPTS + 1,
+            "one up-front rollback + one per attempt",
+        )
         m_commit.assert_not_called()
         self.assertEqual(m_log.call_count, 1, "logs once, on exhaustion")
 
@@ -67,12 +71,14 @@ class TestApplyWhatsappMessageStatus(FrappeTestCase):
             patch.object(webhook.frappe.db, "get_value", return_value=None),
             patch.object(webhook.frappe.db, "set_value") as m_set,
             patch.object(webhook.frappe.db, "commit") as m_commit,
+            patch.object(webhook.frappe.db, "rollback") as m_rb,
             patch.object(webhook.frappe, "log_error") as m_log,
         ):
             webhook.apply_whatsapp_message_status("wamid.unknown", "read")
         m_set.assert_not_called()
         m_commit.assert_not_called()
         m_log.assert_not_called()
+        self.assertEqual(m_rb.call_count, 2, "up-front rollback + no-op-path rollback")
 
     def test_conversation_id_included_when_present(self):
         _m_get, m_set, _m_commit, _m_rb, _m_log = self._run(conversation="CONV-9")

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_message/test_whatsapp_message.py
@@ -2,11 +2,86 @@
 # Copyright (c) 2022, Shridhar Patil and Contributors
 # See license.txt
 
-# import frappe
-from frappe.tests import UnitTestCase
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from frappe_whatsapp.utils import webhook
 
 
-class TestWhatsAppMessage(UnitTestCase):
+class TestWhatsAppMessage(FrappeTestCase):
     """Test whatsapp messages."""
 
     pass
+
+
+class TestApplyWhatsappMessageStatus(FrappeTestCase):
+    """apply_whatsapp_message_status retries through transient 1020/1213 and is non-fatal.
+
+    Fully mocked — the WhatsApp Message row + frappe.db calls are patched, so no DB / no site state.
+    """
+
+    def _run(self, set_value_side_effect=None, name="WA-MSG-1", conversation=None):
+        with (
+            patch.object(webhook.frappe.db, "get_value", return_value=name) as m_get,
+            patch.object(webhook.frappe.db, "set_value", side_effect=set_value_side_effect) as m_set,
+            patch.object(webhook.frappe.db, "commit") as m_commit,
+            patch.object(webhook.frappe.db, "rollback") as m_rb,
+            patch.object(webhook.time, "sleep"),
+            patch.object(webhook.frappe, "log_error") as m_log,
+        ):
+            webhook.apply_whatsapp_message_status("wamid.X", "delivered", conversation=conversation)
+        return m_get, m_set, m_commit, m_rb, m_log
+
+    def test_retries_through_conflict_then_succeeds(self):
+        """Two 1020s then success → set_value retried, committed once, nothing logged."""
+        calls = {"n": 0}
+
+        def se(*a, **k):
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise frappe.QueryDeadlockError("1020 record has changed")
+
+        _m_get, m_set, m_commit, m_rb, m_log = self._run(set_value_side_effect=se)
+        self.assertEqual(m_set.call_count, 3, "set_value retried until it succeeds")
+        self.assertEqual(m_commit.call_count, 1, "commit once, after the successful UPDATE")
+        self.assertEqual(m_rb.call_count, 2, "rollback before each of the 2 retries (fresh snapshot)")
+        m_log.assert_not_called()
+
+    def test_exhaustion_logs_once_and_does_not_raise(self):
+        """Persistent conflict → exhausts attempts, logs once, never raises (non-fatal job)."""
+
+        def se(*a, **k):
+            raise frappe.QueryTimeoutError("1205 lock wait timeout")
+
+        _m_get, m_set, m_commit, m_rb, m_log = self._run(set_value_side_effect=se)  # must not raise
+        self.assertEqual(m_set.call_count, 5, "exactly _STATUS_RETRY_ATTEMPTS attempts")
+        self.assertEqual(m_rb.call_count, 5)
+        m_commit.assert_not_called()
+        self.assertEqual(m_log.call_count, 1, "logs once, on exhaustion")
+
+    def test_missing_message_is_noop(self):
+        """A status for a message we do not store no-ops — no UPDATE, no error."""
+        with (
+            patch.object(webhook.frappe.db, "get_value", return_value=None),
+            patch.object(webhook.frappe.db, "set_value") as m_set,
+            patch.object(webhook.frappe.db, "commit") as m_commit,
+            patch.object(webhook.frappe, "log_error") as m_log,
+        ):
+            webhook.apply_whatsapp_message_status("wamid.unknown", "read")
+        m_set.assert_not_called()
+        m_commit.assert_not_called()
+        m_log.assert_not_called()
+
+    def test_conversation_id_included_when_present(self):
+        _m_get, m_set, _m_commit, _m_rb, _m_log = self._run(conversation="CONV-9")
+        values = m_set.call_args[0][2]  # set_value(doctype, name, values)
+        self.assertEqual(values.get("status"), "delivered")
+        self.assertEqual(values.get("conversation_id"), "CONV-9")
+
+    def test_conversation_id_omitted_when_absent(self):
+        _m_get, m_set, _m_commit, _m_rb, _m_log = self._run(conversation=None)
+        values = m_set.call_args[0][2]
+        self.assertEqual(values.get("status"), "delivered")
+        self.assertNotIn("conversation_id", values)

--- a/frappe_whatsapp/utils/webhook.py
+++ b/frappe_whatsapp/utils/webhook.py
@@ -1,11 +1,21 @@
 """Webhook."""
-import frappe
 import json
+import random
+import time
+
+import frappe
 import requests
 from frappe.utils.password import get_decrypted_password
 from werkzeug.wrappers import Response
 import frappe.utils
 from frappe.utils.background_jobs import get_queues_timeout
+
+# A WhatsApp status UPDATE can hit a transient 1020/1213 under innodb_snapshot_isolation when concurrent
+# Meta callbacks (sent/delivered/read) + the chat "mark as read" race the same row. Retry through it — the
+# write is last-writer-wins + idempotent (re-delivered callbacks re-apply), and each retry's rollback gives
+# a fresh snapshot so it converges.
+_STATUS_RETRY_ATTEMPTS = 5
+_STATUS_RETRY_BASE_S = 0.05
 
 
 @frappe.whitelist(allow_guest=True)
@@ -237,67 +247,44 @@ def _whatsapp_status_queue():
 
 
 def apply_whatsapp_message_status(message_id, status, conversation=None):
-	"""Background job: apply a WhatsApp delivery-status update under READ COMMITTED.
+	"""Background job: apply a WhatsApp delivery-status update, retrying through transient lock conflicts.
 
-	MariaDB snapshot isolation (innodb_snapshot_isolation=ON) raises ER_CHECKREAD (1020) on a plain UPDATE
-	when another connection committed a change to this WhatsApp Message row after this transaction's read
-	view -- e.g. the outbound-send flow finalising the message, or a chat "mark as read". Running the write
-	under READ COMMITTED turns that conflict detection off (last-writer-wins, which is fine for a status
-	field), so the UPDATE just applies. A transaction's isolation is fixed when it starts and Frappe keeps a
-	transaction continuously open, so we capture the connection's current isolation, rollback to end that
-	transaction (without committing pending state), then SET SESSION READ COMMITTED for the next one. The
-	captured level is restored via a guarded helper that can never fail the job. Non-fatal + idempotent: a
-	status for a message we do not store no-ops, and re-delivered callbacks just re-apply.
+	Meta delivers sent/delivered/read (+ retries) as separate callbacks for the same message, and the chat
+	"mark as read" writes the same row, so concurrent status writes race. Under MariaDB snapshot isolation
+	(innodb_snapshot_isolation=ON) a plain UPDATE then raises ER_CHECKREAD (1020) when another connection
+	committed a change to this row since this transaction's read view. The status write is last-writer-wins +
+	idempotent (a missed callback re-applies on the next one), so we just retry: each attempt rolls back first
+	(`frappe.db.rollback()` re-begins the transaction, giving a fresh snapshot) and re-applies, with jittered
+	backoff. Non-fatal — a status for a message we don't store no-ops, and exhausted retries are logged only.
+
+	(We previously tried to run this under READ COMMITTED, but `frappe.db.rollback()` re-begins the transaction
+	with no isolation clause, so the UPDATE still ran at REPEATABLE READ — the retry is isolation-agnostic.)
 	"""
-	prior_isolation = None
-	try:
-		# Capture the connection's current isolation so we restore exactly it (not a hard-coded RR), then end
-		# the open transaction with a rollback (don't commit pending state) and switch to RC, under which
-		# snapshot isolation can't raise 1020 on the write (see docstring).
-		prior_isolation = frappe.db.sql("SELECT @@transaction_isolation")[0][0]
-		frappe.db.rollback()
-		frappe.db.sql("SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED")
-
-		name = frappe.db.get_value("WhatsApp Message", {"message_id": message_id})
-		if not name:
-			# Status for a message not stored here (e.g. sent from another system) — nothing to update.
+	for attempt in range(_STATUS_RETRY_ATTEMPTS):
+		try:
+			name = frappe.db.get_value("WhatsApp Message", {"message_id": message_id})
+			if not name:
+				# Status for a message not stored here (e.g. sent from another system) — nothing to update.
+				return
+			values = {"status": status}
+			if conversation:
+				values["conversation_id"] = conversation
+			frappe.db.set_value("WhatsApp Message", name, values)
+			frappe.db.commit()
 			return
-		values = {"status": status}
-		if conversation:
-			values["conversation_id"] = conversation
-		frappe.db.set_value("WhatsApp Message", name, values)
-		frappe.db.commit()
-	except Exception:
-		frappe.db.rollback()
-		frappe.log_error(
-			title="apply_whatsapp_message_status failed",
-			message=f"message_id={message_id}, status={status}\n{frappe.get_traceback()}",
-		)
-	finally:
-		_restore_session_isolation(prior_isolation)
-
-
-# @@transaction_isolation reports a hyphenated value (e.g. "REPEATABLE-READ"); SET SESSION needs the spaced
-# form. Whitelisted so the restore never interpolates an unexpected value into SQL.
-_ISOLATION_SQL = {
-	"REPEATABLE-READ": "REPEATABLE READ",
-	"READ-COMMITTED": "READ COMMITTED",
-	"READ-UNCOMMITTED": "READ UNCOMMITTED",
-	"SERIALIZABLE": "SERIALIZABLE",
-}
-
-
-def _restore_session_isolation(prior_isolation):
-	"""Restore the session isolation captured before the RC switch. Guarded so a failure here can never fail
-	the WhatsApp status job (nor mask the original error when raised from a `finally`)."""
-	level = _ISOLATION_SQL.get(prior_isolation)
-	if not level:
-		return
-	try:
-		frappe.db.rollback()
-		frappe.db.sql("SET SESSION TRANSACTION ISOLATION LEVEL " + level)
-	except Exception:
-		frappe.log_error(
-			title="apply_whatsapp_message_status: isolation restore failed",
-			message=f"prior={prior_isolation}\n{frappe.get_traceback()}",
-		)
+		except (frappe.QueryDeadlockError, frappe.QueryTimeoutError):
+			frappe.db.rollback()  # re-begins the txn → next attempt reads from a fresh snapshot
+			if attempt == _STATUS_RETRY_ATTEMPTS - 1:
+				frappe.log_error(
+					title="apply_whatsapp_message_status failed",
+					message=f"message_id={message_id}, status={status}\n{frappe.get_traceback()}",
+				)
+				return
+			time.sleep(_STATUS_RETRY_BASE_S * (2**attempt) + random.uniform(0, _STATUS_RETRY_BASE_S))
+		except Exception:
+			frappe.db.rollback()
+			frappe.log_error(
+				title="apply_whatsapp_message_status failed",
+				message=f"message_id={message_id}, status={status}\n{frappe.get_traceback()}",
+			)
+			return

--- a/frappe_whatsapp/utils/webhook.py
+++ b/frappe_whatsapp/utils/webhook.py
@@ -253,18 +253,24 @@ def apply_whatsapp_message_status(message_id, status, conversation=None):
 	"mark as read" writes the same row, so concurrent status writes race. Under MariaDB snapshot isolation
 	(innodb_snapshot_isolation=ON) a plain UPDATE then raises ER_CHECKREAD (1020) when another connection
 	committed a change to this row since this transaction's read view. The status write is last-writer-wins +
-	idempotent (a missed callback re-applies on the next one), so we just retry: each attempt rolls back first
-	(`frappe.db.rollback()` re-begins the transaction, giving a fresh snapshot) and re-applies, with jittered
-	backoff. Non-fatal — a status for a message we don't store no-ops, and exhausted retries are logged only.
+	idempotent (a missed callback re-applies on the next one), so we just retry: we roll back once up front (a
+	reused worker connection can carry an open transaction with a stale read view) and again after each transient
+	conflict — every `frappe.db.rollback()` re-begins the transaction with a fresh snapshot — then re-apply, with
+	jittered backoff. Non-fatal — a status for a message we don't store no-ops, and exhausted retries are logged only.
 
 	(We previously tried to run this under READ COMMITTED, but `frappe.db.rollback()` re-begins the transaction
 	with no isolation clause, so the UPDATE still ran at REPEATABLE READ — the retry is isolation-agnostic.)
 	"""
+	# A reused RQ worker connection can carry an open transaction (stale read view) from a prior job; end it so
+	# attempt 1 also starts from a fresh snapshot, not just the post-conflict retries.
+	frappe.db.rollback()
 	for attempt in range(_STATUS_RETRY_ATTEMPTS):
 		try:
 			name = frappe.db.get_value("WhatsApp Message", {"message_id": message_id})
 			if not name:
 				# Status for a message not stored here (e.g. sent from another system) — nothing to update.
+				# Roll back so this job's read view isn't left open on the shared worker connection.
+				frappe.db.rollback()
 				return
 			values = {"status": status}
 			if conversation:


### PR DESCRIPTION
…/1213

The #6c READ-COMMITTED switch never bound the UPDATE's transaction: frappe.db.rollback() re-begins a transaction (START TRANSACTION, no isolation clause) BEFORE the SET SESSION ... READ COMMITTED runs, so apply_whatsapp_message_status's set_value still ran at REPEATABLE READ and snapshot isolation kept raising 1020 (ER_CHECKREAD) when a gunicorn writer -- chat/inbox "mark as read", outbound-send finalisation -- committed the same WhatsApp Message row concurrently. The dedicated whatsapp queue can't help: those are different connections, not other status jobs.

Replace the RC dance (+ _restore_session_isolation / _ISOLATION_SQL) with a bounded retry: on QueryDeadlockError/QueryTimeoutError -> rollback (re-begins -> fresh snapshot)
+ jittered backoff + retry, <=5 attempts; missing message no-ops; exhaustion logs once, non-fatal. The status write is last-writer-wins + idempotent (Meta re-delivers), so retrying is safe. + 5 mocked tests.