### PR TITLE
fix: pylint CI failures — real bugs + scope workflow to errors-only

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,17 +1,17 @@
 name: Pylint
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -20,4 +20,9 @@ jobs:
         pip install pylint
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py')
+        # Errors only: frappe/requests aren't installed here (import-error,
+        # no-member), and DocType fields are set dynamically from meta
+        # (access-member-before-definition).
+        pylint --errors-only \
+          --disable=import-error,no-member,access-member-before-definition \
+          $(git ls-files '*.py')

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.py
@@ -227,6 +227,8 @@ class WhatsAppNotification(Document):
                     }
                 )
 
+            url = None
+            filename = None
             if self.attach_document_print:
                 key = doc.get_document_share_key()  # noqa
                 print_format = "Standard"
@@ -356,8 +358,9 @@ class WhatsAppNotification(Document):
             "authorization": f"Bearer {token}",
             "content-type": "application/json",
         }
+        success = False
+        error_message = None
         try:
-            success = False
             response = make_post_request(
                 f"{whatsapp_account.url}/{whatsapp_account.version}/{whatsapp_account.phone_id}/messages",
                 headers=headers, data=json.dumps(data)

--- a/frappe_whatsapp/utils/template_utils.py
+++ b/frappe_whatsapp/utils/template_utils.py
@@ -1,3 +1,6 @@
+import frappe
+
+
 def get_template_values(template_name, recipient_data=None):
     """
     Get the template values for a WhatsApp template


### PR DESCRIPTION
The Pylint workflow ran unconfigured pylint on Python 3.8-3.10, which can never pass: frappe/requests aren't installed in the job (1000+ import-errors) and Python 3.8 is no longer available on ubuntu-latest.

Real errors it did catch, fixed here:
- template_utils.py used frappe without importing it (NameError at runtime)
- whatsapp_notification.notify: `success`/`error_message` were referenced in `finally` before assignment when the request raised early
- send_template_message: `url`/`filename` could be unbound when a DOCUMENT/IMAGE header template had no attachment source configured

Workflow now runs pylint --errors-only on 3.10/3.11 with import-error, no-member and access-member-before-definition disabled (frappe isn't importable in CI and DocType fields are set dynamically from meta).